### PR TITLE
Updated dependencies: SSSOM.py

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,7 +29,7 @@ PyYAML = "*"
 PyLD = "*"
 PyGithub = "*"
 py2neo = "*"
-sssom = {editable = true, git = "https://github.com/mapping-commons/sssom-py"}
+sssom = {editable = true, git = "https://github.com/mapping-commons/sssom-py", ref = "b5ffb0d71f7ec6d06991be25f5853682c1c107d9"}
 prefixcommons = "*"
 shortuuid = "*"
 pyrdfa3 = "*"


### PR DESCRIPTION
## Related to
Issues: https://github.com/cancerDHC/ccdh-terminology-service/issues/28, https://github.com/cancerDHC/ccdh-terminology-service/issues/30, https://github.com/cancerDHC/ccdh-terminology-service/issues/32

Pull requests
- `ncihtan/HTAN-data-pipeline` submodule: https://github.com/ncihtan/schematic/pull/10

## Changes
```
Updated dependencies
- SSSOM.py: Locked in to a specific commit that currently works for us, following a PR that recently fixed the [linkml/linkml_runtime].utils related issue. Future development will probably break this dependency for us, so good to lock in now.
- ordered-set: Switched from CPython-based non-precompiled 'orderedset' to pure Python-based 'ordered-set' functionality. The API seems similar / same, and should be especially OK to do this because it doesn't look like this it's being used yet in the project.
```

## Potential improvements TODO
I didn't update the lockfile. Still working on that.