### PR TITLE
docker-compose updates: dev file, port changes, & slightly more

### DIFF
--- a/ccdh/importers/importer.py
+++ b/ccdh/importers/importer.py
@@ -210,10 +210,7 @@ class Importer:
     def import_all():
         """Import data from all nodes / data sources"""
         Importer(neo4j_graph()).import_ncit()
-
-        # PDC: Disabled until resolution of this issue: https://github.com/cancerDHC/ccdh-terminology-service/issues/54
-        # Importer(neo4j_graph()).import_node_attributes(PdcImporter.read_data_dictionary())
-
+        Importer(neo4j_graph()).import_node_attributes(PdcImporter.read_data_dictionary())
         Importer(neo4j_graph()).import_node_attributes(GdcImporter.read_data_dictionary())
         Importer(neo4j_graph()).import_harmonized_attributes(CrdcHImporter.read_harmonized_attributes())
         Importer(neo4j_graph()).import_ncit_mapping(GdcImporter.read_ncit_mappings(), 'GDC')

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,27 +1,27 @@
-# Production environment
+# Dev environment: Use similar instructions to those in `quick_start.md`, and running: docker-compose -f docker-compose-dev.yml -p ccdh-dev build; docker-compose -f docker-compose-dev.yml -p ccdh-dev up -d
 version: "3"
 services:
-  ccdh-api:
+  ccdh-api-dev:
     build:
       dockerfile: ./docker/ccdh-api/Dockerfile
       context: ..
-    container_name: ccdh-api
+    container_name: ccdh-api-dev
     restart: on-failure
     ports:
-      - "7070:8000"
+      - "6060:8000"
     env_file:
       - .env
     depends_on:
-      ccdh-neo4j:
+      ccdh-neo4j-dev:
         condition: service_healthy
-      ccdh-redis:
+      ccdh-redis-dev:
         condition: service_healthy
 
-  ccdh-redis:
+  ccdh-redis-dev:
     image: "redis:alpine"
-    container_name: ccdh-redis
-    # ports:
-    #  - "6379:6379"
+    container_name: ccdh-redis-dev
+    ports:
+      - "6380:6379"
     volumes:
      - ./redis-data:/var/lib/redis
     healthcheck:
@@ -30,9 +30,9 @@ services:
       timeout: 10s
       retries: 30
 
-  ccdh-neo4j:
+  ccdh-neo4j-dev:
     image: neo4j:4.1.3
-    container_name: ccdh-neo4j
+    container_name: ccdh-neo4j-dev
     restart: always
     volumes:
       - ./neo4j/logs:/logs
@@ -43,8 +43,8 @@ services:
       - ./neo4j/wrapper.sh:/opt/wrapper.sh
       - ./neo4j/initialize_neo4j.sh:/opt/initialize_neo4j.sh
       - ./neo4j/cyphers:/cyphers
-    # ports:
-    #  - $NEO4J_BOLT_PORT:7687
+    ports:
+      - "6687:7687"
     environment:
       NEO4J_AUTH: $NEO4J_USERNAME/$NEO4J_PASSWORD
       NEO4J_dbms_memory_heap_max__size: 8G
@@ -58,5 +58,5 @@ services:
     entrypoint: /opt/wrapper.sh
 
 volumes:
-  ccdh-neo4j:
-  ccdh-redis:
+  ccdh-neo4j-dev:
+  ccdh-redis-dev:

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -9,8 +9,6 @@ services:
     restart: on-failure
     ports:
       - "6060:8000"
-    env_file:
-      - .env
     depends_on:
       ccdh-neo4j-dev:
         condition: service_healthy

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -1,3 +1,4 @@
+# Test environment
 version: "3"
 services:
   ccdh-api-test:
@@ -18,9 +19,9 @@ services:
 
   ccdh-redis-test:
     image: "redis:alpine"
-    container_name: redis-test
-    ports:
-      - "6380:6379"
+    container_name: ccdh-redis-test
+    # ports:
+    #  - "6380:6379"
     volumes:
      - ./redis-data:/var/lib/redis
     healthcheck:
@@ -31,7 +32,7 @@ services:
 
   ccdh-neo4j-test:
     image: neo4j:4.1.3
-    container_name: neo4j-test
+    container_name: ccdh-neo4j-test
     restart: always
     volumes:
       - ./neo4j/logs:/logs
@@ -42,8 +43,8 @@ services:
       - ./neo4j/wrapper.sh:/opt/wrapper.sh
       - ./neo4j/initialize_neo4j.sh:/opt/initialize_neo4j.sh
       - ./neo4j/cyphers:/cyphers
-    ports:
-      - "6687:7687"
+    # ports:
+    #  - "6687:7687"
     environment:
       NEO4J_AUTH: $NEO4J_USERNAME/$NEO4J_PASSWORD
       NEO4J_dbms_memory_heap_max__size: 8G
@@ -58,4 +59,4 @@ services:
 
 volumes:
   ccdh-neo4j-test:
-  ccdh-redis:
+  ccdh-redis-test:

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -9,8 +9,6 @@ services:
     restart: on-failure
     ports:
       - "6060:8000"
-    env_file:
-      - .env.test
     depends_on:
       ccdh-neo4j-test:
         condition: service_healthy
@@ -49,7 +47,7 @@ services:
       NEO4J_AUTH: $NEO4J_USERNAME/$NEO4J_PASSWORD
       NEO4J_dbms_memory_heap_max__size: 8G
     env_file:
-      - .env.test
+      - .env
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7474"]
       interval: 15s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     restart: on-failure
     ports:
       - "7070:8000"
-    env_file:
-      - .env
     depends_on:
       ccdh-neo4j:
         condition: service_healthy

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -32,14 +32,13 @@ In the `docker/` folder, Create a `.env` file with required environment variable
 
 The `.env` file should contain the following:
 
-```
-NEO4J_BOLT_URI=bolt://ccdh-neo4j:7687
+```shell
 NEO4J_USERNAME=<username>
 NEO4J_PASSWORD=<password>
 NEO4J_HOST=ccdh-neo4j
 NEO4J_BOLT_PORT=7687
 REDIS_URL=redis://ccdh-redis:6379
-USER_ACCESS_TOKEN=token
+USER_ACCESS_TOKEN=<token>
 ```
 
 Choose a <username> and <password>. As for `USER_ACCESS_TOKEN`, this is used for [GitHub workflow integration](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) with the [CCDH Model repository](https://github.com/cancerDHC/ccdhmodel). If you have access to that repository, you should use a [GitHub personal access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) and set `USER_ACCESS_TOKEN` to that. The port, host, and 'bolt uri' have been auto-filled for you, but these are configurable if you want to change them.
@@ -62,11 +61,10 @@ docker-compose build
 If everything works, spin up the containers
 
 ```shell
-docker-compose up
+docker-compose up -d
 ```
 
-After the docker containers are up, log onto the ccdh-api container and
-load data. 
+After the docker containers are up, log onto the ccdh-api container and load data. 
 
 ```shell
 docker exec -it ccdh-api /bin/bash
@@ -74,4 +72,4 @@ python -m ccdh.importers.importer
 ```
 
 After data is loaded, the server will be running on a local port at 7070. You can visit
-http://localhost:7070. 
+[http://localhost:7070](http://localhost:7070). 

--- a/docs/setting_up_test.md
+++ b/docs/setting_up_test.md
@@ -1,4 +1,5 @@
 # Setting up a testing server with dockers
+## Environment files
 First, you will want to have 2 clones of this repository. One should be for production ('prod'), and the other for test.
 
 To set up a testing server with docker containers, use `docker/docker-compose-test.yml`. 
@@ -6,15 +7,34 @@ To set up a testing server with docker containers, use `docker/docker-compose-te
 Create a file `.env.test` in the `docker` directory. It should have similar content as `.env`. Then, you should back up
 the prod `.env` file; e.g. you can copy it and can call it `.env.prod`.
 
-The variable `NEO4J_BOLT_PORT`, `NEO4J_HOST`, `NEO4J_BOLT_URI`, and `REDIS_URL` for `.env.test` need to be different 
-than what is in `.env.prod`. The simple way to do this for Neo4J and Redis host names in the production `.env` is to use
-the service names in `docker-compose.yml`, and to use the service names in `docker-compose-test.yml` for the test 
-server's `env.test`.
+The variable `NEO4J_BOLT_PORT`, `NEO4J_HOST`, and `REDIS_URL` for `.env.test` need to be different 
+than what is in `.env.prod`. The host names in the `.env` and `.env.test` need to match the `container_name` or the
+service name in `docker-compose.yml` and `docker-compose-test.yml` respectively. The ports also need to be different.
 
-When you've finished your `.env.test` file, overwrite `.env` with those same exact contents. This is because `config.py`
-will always look for `.env`, regardless of the environment. We plan to fix this in a future update.
+### Example `.env`
+```sh
+# .env file for running docker environments: prod
+NEO4J_USERNAME=<username>
+NEO4J_PASSWORD=<password>
+NEO4J_HOST=ccdh-neo4j
+NEO4J_BOLT_PORT=7687
+REDIS_URL=redis://ccdh-redis:6379
+USER_ACCESS_TOKEN=<token>
+```
 
-Run the following to start up the containers.
+### Example `.env.test`
+```sh
+# .env file for running in docker environments: test
+NEO4J_USERNAME=<username>
+NEO4J_PASSWORD=<password>
+NEO4J_HOST=ccdh-neo4j-test
+NEO4J_BOLT_PORT=6687
+REDIS_URL=redis://ccdh-redis-test:6380
+USER_ACCESS_TOKEN=<token>
+
+```
+
+## Run the following to start up the containers.
 
 ```
 cd docker

--- a/docs/setting_up_test.md
+++ b/docs/setting_up_test.md
@@ -36,7 +36,7 @@ USER_ACCESS_TOKEN=<token>
 
 ## Run the following to start up the containers.
 
-```
+```sh
 cd docker
 docker-compose -f docker-compose-test.yml -p ccdh-test build
 docker-compose -f docker-compose-test.yml -p ccdh-test up -d


### PR DESCRIPTION
## Important
This is currently just a draft. Not yet tested.

## Updates
- Added docker-compose-dev.yml: Retained redis/neo4j port forwarding
- Updates to docker-compose.yml and docker-compose-test.yml: Removed redis/neo4j port forwarding.
- Updated documentation concerning docker
- All docker-compose files: Made service names and container_name the same.